### PR TITLE
Update createMQTTcerts.sh

### DIFF
--- a/createMQTTcerts.sh
+++ b/createMQTTcerts.sh
@@ -317,9 +317,3 @@ select opt in $OPTIONSLIST; do
     fi
 done
 
-printf "${CYAN}Trying to add TwinCAT_XAR user to mosquitto password file...${NC}\n"
-mosquitto_passwd -b -c ${MOSQPATH}mqttuser.txt TwinCAT_XAR qUeriUo4812dsdaf
-printf "${CYAN}Trying to add TwinCAT_XAE user to mosquitto password file...${NC}\n"
-mosquitto_passwd -b ${MOSQPATH}mqttuser.txt TwinCAT_XAE Trweriuo5678dsXy
-
-


### PR DESCRIPTION
user/passwords authentication is not in place if require_certificate and use_identity_as_username is true;

see mosquitto.conf man-page:
When using certificate based encryption there are three options that affect authentication. The first is require_certificate, which may be set to true or false. If false, the SSL/TLS component of the client will verify the server but there is no requirement for the client to provide anything for the server: authentication is limited to the MQTT built in username/password. If require_certificate is true, the client must provide a valid certificate in order to connect successfully. In this case, the second and third options, use_identity_as_username and use_subject_as_username, become relevant. If set to true, use_identity_as_username causes the Common Name (CN) from the client certificate to be used instead of the MQTT username for access control purposes. The password is not used because it is assumed that only authenticated clients have valid certificates.